### PR TITLE
feat: expose the `output_unit` option to the end-user through kwargs and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Alternatively, you can run any test passing the function/s to profile from the c
 $ pytest --line-profile path.to.function_to_be_profiled [...] 
 ```
 
+The `line-profiler` library offer flexibility to change the output time units, to change the default output time unit you can set `output_unit` in the function decorator.
+For example: 
+```python
+
+@pytest.mark.line_profile.with_args(f, g, output_unit=1e-3)
+def test_as_mark():
+    assert g() == 450
+
+```
 
 ## Contributing
 


### PR DESCRIPTION
Hi really cool tool, thanks for publishing this for everyone to use! 

As mentioned in [#9](https://github.com/mgaitan/pytest-line-profiler/issues/9) a useful feature of line-profiler is the option to change the output time unit. This solution grabs the `output_unit` from the function decorator using kwarg with a default value.